### PR TITLE
Add environment configuration for SIPS-TEST

### DIFF
--- a/.env/.env.development
+++ b/.env/.env.development
@@ -13,6 +13,4 @@ VITE_AUTH_APP_APP_VIEWER_GROUP_NAME=Unity_Viewer
 VITE_ADS_URL=http://uads-test-dockstore-deploy-lb-1762603872.us-west-2.elb.amazonaws.com:9998
 
 # SPS
-#VITE_SPS_WPST_ENDPOINT=http://aaed06716800f4ead8e75815506a2999-2059110582.us-west-2.elb.amazonaws.com:5001/   # Direct
-#VITE_SPS_WPST_ENDPOINT=https://1gp9st60gd.execute-api.us-west-2.amazonaws.com/dev/ades-wpst/   # Via API GATEWAY
 VITE_SPS_WPST_ENDPOINT=https://d3vc8w9zcq658.cloudfront.net/ades-wpst/  # Via CloudFront

--- a/.env/.env.integration
+++ b/.env/.env.integration
@@ -13,6 +13,4 @@ VITE_AUTH_APP_APP_VIEWER_GROUP_NAME=Unity_Viewer
 VITE_ADS_URL=http://uads-test-dockstore-deploy-lb-1762603872.us-west-2.elb.amazonaws.com:9998
 
 # SPS
-#VITE_SPS_WPST_ENDPOINT=http://aaed06716800f4ead8e75815506a2999-2059110582.us-west-2.elb.amazonaws.com:5001/   # Direct
-#VITE_SPS_WPST_ENDPOINT=https://1gp9st60gd.execute-api.us-west-2.amazonaws.com/dev/ades-wpst/   # Via API GATEWAY
 VITE_SPS_WPST_ENDPOINT=https://d3vc8w9zcq658.cloudfront.net/ades-wpst/  # Via CloudFront

--- a/.env/.env.sips-test
+++ b/.env/.env.sips-test
@@ -1,0 +1,16 @@
+# GENERAL
+VITE_ADMIN_EMAIL=anil.natha@jpl.nasa.gov
+
+# Auth
+VITE_AUTH_OAUTH_CLIENT_ID=SET_IN_INTEGRATION_DOT_LOCAL_FILE
+VITE_AUTH_OAUTH_REDIRECT_URI=https://dxebrgu0bc9w7.cloudfront.net/unity-sips-test/dashboard
+VITE_AUTH_OAUTH_LOGOUT_ENDPOINT=https://unitysds-test.auth.us-west-2.amazoncognito.com/logout
+VITE_AUTH_OAUTH_PROVIDER_URL=https://unitysds-test.auth.us-west-2.amazoncognito.com/oauth2
+VITE_AUTH_APP_ADMIN_GROUP_NAME=Unity_Admin
+VITE_AUTH_APP_APP_VIEWER_GROUP_NAME=Unity_Viewer
+
+# ADS
+VITE_ADS_URL=http://uads-test-dockstore-deploy-lb-1762603872.us-west-2.elb.amazonaws.com:9998
+
+# SPS
+VITE_SPS_WPST_ENDPOINT=https://dxebrgu0bc9w7.cloudfront.net/unity-sips-test/ades-wpst/

--- a/.env/.env.test
+++ b/.env/.env.test
@@ -1,0 +1,16 @@
+# GENERAL
+VITE_ADMIN_EMAIL=anil.natha@jpl.nasa.gov
+
+# Auth
+VITE_AUTH_OAUTH_CLIENT_ID=SET_IN_INTEGRATION_DOT_LOCAL_FILE
+VITE_AUTH_OAUTH_REDIRECT_URI=https://dxebrgu0bc9w7.cloudfront.net/dashboard
+VITE_AUTH_OAUTH_LOGOUT_ENDPOINT=https://unitysds-test.auth.us-west-2.amazoncognito.com/logout
+VITE_AUTH_OAUTH_PROVIDER_URL=https://unitysds-test.auth.us-west-2.amazoncognito.com/oauth2
+VITE_AUTH_APP_ADMIN_GROUP_NAME=Unity_Admin
+VITE_AUTH_APP_APP_VIEWER_GROUP_NAME=Unity_Viewer
+
+# ADS
+VITE_ADS_URL=http://uads-test-dockstore-deploy-lb-1762603872.us-west-2.elb.amazonaws.com:9998
+
+# SPS
+VITE_SPS_WPST_ENDPOINT=https://dxebrgu0bc9w7.cloudfront.net/ades-wpst/  # Via CloudFront

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2023-11-13
+
+- Updated environment configurations to account for SIPS-TEST deployments
+
 ## [0.2.0] - 2023-10-02
 
 - Updated Job Monitoring Dashboard, data is fetched from WPS-T Endpoint

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build-integration": "tsc && vite build --mode integration --base=/dashboard/",
-    "build-staging": "tsc && vite build --mode staging --base=/dashboard/",
+    "build-test": "tsc && vite build --mode test --base=/dashboard/",
+    "build-sips-test": "tsc && vite build --mode sips-test --base=/unity-sips-test/dashboard/",
     "build-prod": "tsc && vite build --mode production",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "unity-ui",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Purpose

Updated environment configurations to account for deployment to SIPS TEST MCP account.

## Proposed Changes
- Changed environment configs to account for SIPS MCP account deployment. 
- Fixed naming environment configurations where "staging" was usage. Now using "test" for consistency.

## Issues

Resolves #10 
