### PR TITLE
Fix brand link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2023-12-12
+- Fixed link associated with logo on mobile platforms
+
 ## [0.3.0] - 2023-11-13
 
 - Updated environment configurations to account for SIPS-TEST deployments

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "unity-ui",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -93,6 +93,7 @@ export default function Navbar() {
                min={800}
             >
                <NavbarBrand
+                  link="/"
                   logo={<img src={UnityLogo} alt="Unity Logo" style={{ height: '24px', width: '24px' }}/>}
                   title="Unity"
                   version={uiVersion}


### PR DESCRIPTION
## Purpose

The Unity Logo wasn't linking correctly at the mobile breakpoint, fixed this by adding the link attribute for this breakpoint.

## Proposed Changes
- [FIX] Unity Logo on mobile breakpoints now links to the Unity UI's homepage (e.g. "/")
