### PR TITLE
Updated proxy name to be `ui` instead of `dashboard`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added health check URL to health dashboard [#40](https://github.com/unity-sds/unity-ui/issues/40)
 - Fixed health dashboard column resizer element z-index
 - Added cards to homepage [#38](https://github.com/unity-sds/unity-ui/issues/38)
+- Updated router configuration to improve URL readability.  URLs no longer contain router information using a hash (#39). [#39](https://github.com/unity-sds/unity-ui/issues/39
+- Updated home page route to be located at `/home` and the route `/` redirects to it. [#39](https://github.com/unity-sds/unity-ui/issues/39)
+- Updated application basename configuration to use the proxy name `ui` instead of `dashboard` [#45](https://github.com/unity-sds/unity-ui/issues/45)
 
 ## [0.7.0] 2024-09-27
 - Updated node version lts/iron

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,7 +10,7 @@ import './index.css'
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <HelmetProvider>
-      <BrowserRouter basename={`${Config['general']['project']}/${Config['general']['venue']}/dashboard`}>
+      <BrowserRouter basename={`${Config['general']['project']}/${Config['general']['venue']}/ui`}>
         <Routes>
           <Route path="*" Component={AuthorizationWrapper}/>
         </Routes>


### PR DESCRIPTION
## Purpose

The name, `dashboard` has been updated to be `ui` in our router basename configuration to match our [proxy update in our terraform configuration](https://github.com/unity-sds/unity-ui-infra/issues/15).

## Proposed Changes

- [CHANGE] Basename parameter change to `ui` from `dashboard`

## Issues

Resolves #45 

## Testing

Tested locally and by manually deploying an instance to Unity-Venue-Dev.