### PR TITLE
Add hard coded STAC browser links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated router configuration to improve URL readability.  URLs no longer contain router information using a hash (#39). [#39](https://github.com/unity-sds/unity-ui/issues/39
 - Updated home page route to be located at `/home` and the route `/` redirects to it. [#39](https://github.com/unity-sds/unity-ui/issues/39)
 - Updated application basename configuration to use the proxy name `ui` instead of `dashboard` [#45](https://github.com/unity-sds/unity-ui/issues/45)
+- Added hard-coded links for STAC Browser for the unity/dev and unity/test venues [#47](https://github.com/unity-sds/unity-ui/issues/47)
 
 ## [0.7.0] 2024-09-27
 - Updated node version lts/iron

--- a/src/state/slices/healthSlice.ts
+++ b/src/state/slices/healthSlice.ts
@@ -44,6 +44,46 @@ const getItems = () => {
 
   let serviceItems:Service[] = Array<Service>();
 
+  if( project === "UNITY" && venue === 'DEV') {
+
+    serviceItems = [
+      {
+        componentName: "STAC Browser",
+        ssmKey: "",
+        healthCheckUrl: "",
+        landingPageUrl: "https://www.dev.mdps.mcp.nasa.gov:4443/data/stac_browser/",
+        healthChecks: [
+          {
+            status: "UNKNOWN",
+            httpResponseCode: "",
+            date: ""
+          }
+        ]
+      }
+    ];
+
+  }
+
+  if( project === "UNITY" && venue === 'TEST') {
+
+    serviceItems = [
+      {
+        componentName: "STAC Browser",
+        ssmKey: "",
+        healthCheckUrl: "",
+        landingPageUrl: "https://www.test.mdps.mcp.nasa.gov:4443/data/stac_browser/",
+        healthChecks: [
+          {
+            status: "UNKNOWN",
+            httpResponseCode: "",
+            date: ""
+          }
+        ]
+      }
+    ];
+
+  }
+
   if( project === "UNITY" && venue === 'OPS') {
 
     serviceItems = [
@@ -61,6 +101,7 @@ const getItems = () => {
         ]
       }
     ];
+
   }
 
   if( project === "EMIT" && venue === "DEV" ) {


### PR DESCRIPTION
## Purpose

STAC Browser is not currently integrated with the Health API so we have added links for the unity/dev and unity/test venues so we may test them from the UI.

## Proposed Changes
- [ADD] Links to STAC Browser for the unity/dev and unity/test venues have been hard-coded in our router configuration for testing.

## Issues

#47 

## Testing

Tested link addition locally. While the links are added properly, the links themselves do not work due to cognito cookie/token issues. We hope that by adding these links it will help facilitate debugging and testing of the linked service.
