### PR TITLE
Updated Docker workflow so that it is triggered by the creation of a tag and said tag label is used to tag the built Docker image

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,10 +1,12 @@
 name: Docker Build and Push
 
 on:
+  release:
+    types:
+      - published
   push:
-    branches: 
-      - "chore/*"
-    tags: ["[0-9]+.[0-9]+.[0-9]+(-stable|-unstable)*"]
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,7 +3,7 @@ name: Docker Build and Push
 on:
   push:
     tags:
-      - "[0-9]+.[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+([-]\\S*)?"
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: 
       - "chore/*"
-    tags: ["[0-9]+.[0-9]+.[0-9]+(-(stable|unstable)+)*"]
+    tags: ["[0-9]+.[0-9]+.[0-9]+(-stable|-unstable)*"]
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,9 +2,12 @@ name: Docker Build and Push
 
 on:
   push:
-    branches:
-      - main  # or any other branch you want to trigger the workflow
-      - "features/*"
+    tags: ["v[0-9]+.[0-9]+.[0-9]+(-(stable|unstable)+)*"]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_TAG: ${{ github.ref_name }}
 
 jobs:
   build-and-push:
@@ -20,11 +23,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and Push "Latest" Docker image
-        id: build-and-push-latest
-        uses: docker/build-push-action@v5
+      - name: Build and Push tagged Docker image
+        id: build-tag-push-latest
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ghcr.io/${{ github.repository }}/unity-ui-application:latest  # replace with your image name and tag
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/unity-portal-application:${{ env.IMAGE_TAG }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,6 +2,8 @@ name: Docker Build and Push
 
 on:
   push:
+    branches: 
+      - "chore/*"
     tags: ["[0-9]+.[0-9]+.[0-9]+(-(stable|unstable)+)*"]
 
 env:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,9 +1,6 @@
 name: Docker Build and Push
 
 on:
-  release:
-    types:
-      - published
   push:
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,7 +2,7 @@ name: Docker Build and Push
 
 on:
   push:
-    tags: ["v[0-9]+.[0-9]+.[0-9]+(-(stable|unstable)+)*"]
+    tags: ["[0-9]+.[0-9]+.[0-9]+(-(stable|unstable)+)*"]
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,7 +3,8 @@ name: Docker Build and Push
 on:
   push:
     tags:
-      - "[0-9]+.[0-9]+.[0-9]+(-[0-9a-zA-Z]+)?"
+      - "[0-9]+.[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+-[0-9a-zA-Z]+"
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -26,7 +26,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and Push tagged Docker image
-        id: build-tag-push-latest
+        id: build-tag-push-image
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,7 +3,7 @@ name: Docker Build and Push
 on:
   push:
     tags:
-      - "[0-9]+.[0-9]+.[0-9]+([-]\\S*)?"
+      - "[0-9]+.[0-9]+.[0-9]+(-[0-9a-zA-Z]+)?"
 
 env:
   REGISTRY: ghcr.io

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] (Unreleased)
+- Changed Docker image build workflow is triggered when a tag is created and no longer triggered when code is merged to `main` or `features/*` branches [#51](https://github.com/unity-sds/unity-ui/issues/51)
+- Changed Docker image build workflow so that it uses the image name `unity-portal-application` instead of `unity-ui-application`
+
 ## [0.8.0] 2025-01-14
 - Added support to report on when health API endpoint is not available in navbar and on health dashboard
 - Fixed clickable area of navbar menu items


### PR DESCRIPTION
## Purpose

This PR addresses the need to update our Docker image build workflow.

## Proposed Changes
- [CHANGE] Docker image build workflow is triggered when a tag is created and no longer triggered when code is merged to `main` or `features/*` branches
- [CHANGE] Updated image name from `unity-ui-application` to `unity-portal-application`
## Issues
- #51 
## Testing
- Tested on GH by creating tags and observed github action behavior against the branch referenced in this PR.