### PR TITLE
Add project and venue to navbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.9.1] (Unreleased)
+## [0.9.0] (Unreleased)
+- Changed project and venue information location. This information is now available in the navbar instead of on the homepage of the application [#59](https://github.com/unity-sds/unity-portal/issues/59)
 - Changed Docker image build workflow is triggered when a tag is created and no longer triggered when code is merged to `main` or `features/*` branches [#51](https://github.com/unity-sds/unity-ui/issues/51)
 - Changed Docker image build workflow so that it uses the image name `unity-portal-application` instead of `unity-ui-application`
 - Rebranded the application's project references so that they state "MDPS" instead of "Unity" [#55](https://github.com/unity-sds/unity-portal/issues/55)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "unity-ui",
   "private": true,
-  "version": "0.8.0",
+  "version": "0.9.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -43,6 +43,8 @@ export default function Navbar() {
   const uiVersion = Config['general']['version'];
   const basePath = Config['general']['basePath'];
   const appTitle = Config['general']['appTitle'];
+  const project = Config['general']['project'];
+  const venue = Config['general']['venue'];
 
   const healthState = useAppSelector((state) => {
     return state.health;
@@ -73,6 +75,8 @@ export default function Navbar() {
           title={appTitle}
           version={uiVersion}
         />
+        <div className="st-react-navbar-label">Project: {project}</div>
+        <div className="st-react-navbar-label">Venue: {venue}</div>
         <NavbarContent
           align="right"
           full
@@ -138,6 +142,8 @@ export default function Navbar() {
           title={appTitle}
           version={uiVersion}
         />
+        <div className="st-react-navbar-label">Project: {project}</div>
+        <div className="st-react-navbar-label">Venue: {venue}</div>
         <NavbarContent
           align="right"
           full
@@ -214,8 +220,17 @@ export default function Navbar() {
             <MenuItem onClick={logout}>
               Logout
               <MenuRightSlot>
-                  <IconArrowRight />
+                <IconArrowRight />
               </MenuRightSlot>
+            </MenuItem>
+            <MenuLabel>
+              MDPS Environment
+            </MenuLabel>
+            <MenuItem disabled className="text-transform-none">
+              Project: {project}
+            </MenuItem>
+            <MenuItem disabled className="text-transform-none">
+              Venue: {venue}
             </MenuItem>
           </Menu>
         </NavbarContent>

--- a/src/routes/home/index.tsx
+++ b/src/routes/home/index.tsx
@@ -1,4 +1,3 @@
-import Config from "../../Config";
 import { Card } from "../../components/Card";
 
 import { DocumentMeta } from "../../components/DocumentMeta/DocumentMeta";
@@ -6,9 +5,6 @@ import { useAppSelector } from "../../state/hooks";
 import { formatRoute } from "../../utils/strings";
 
 function Home() {
-
-  const project = Config['general']['project'];
-  const venue = Config['general']['venue'];
 
   const healthState = useAppSelector((state) => {
     return state.health;
@@ -61,8 +57,6 @@ function Home() {
       />
       <div className="mdps-main-view">
         <h1>Home</h1>
-        <div>Project: <strong>{project}</strong></div>
-        <div>Venue: <strong>{venue}</strong></div>
         <div className="mdps-card-container">
           {appCards}
         </div>

--- a/src/styles/components/_Navbar.scss
+++ b/src/styles/components/_Navbar.scss
@@ -1,0 +1,5 @@
+.st-react-navbar-label {
+  color: var(--mdps-white);
+  font-weight: 700;
+  padding-left: 50px;
+}

--- a/src/styles/mdps-stellar.css
+++ b/src/styles/mdps-stellar.css
@@ -70,6 +70,10 @@
   word-wrap: break-word;
 }
 
+.st-react-menu-content .st-react-menu-item.text-transform-none {
+  text-transform: none;
+}
+
 /* Navbar */
 
 .st-react-navbar {

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -15,5 +15,6 @@
 @import "components/_Cards";
 @import "components/_Containers";
 @import "components/_Grid";
+@import "components/Navbar";
 @import "components/_Icons";
 @import "components/_Pills";


### PR DESCRIPTION
## Purpose

This purpose of this PR is to address project and venue labeling updates

## Proposed Changes
- [CHANGE] Project and Venue information has been moved from the home page view to exist in the menu bar and varies in placement depending on the browser viewport size.

## Issues

Resolves #59 

## Testing

Tested locally